### PR TITLE
カレンダーを出力してくれるプログラムの作成

### DIFF
--- a/ruby/calender.rb
+++ b/ruby/calender.rb
@@ -1,0 +1,59 @@
+require 'date'
+require 'optparse'
+
+# wdayは日曜始まりに対し、作成したいカレンダーは月曜始まりなので対応させる
+# cwdayを使えばこの関数は不要になる
+def change_for_monday_start(val_sunday_start)
+    if val_sunday_start == 0
+        6
+    else
+        val_sunday_start - 1
+    end
+end
+
+# -mオプションがある場合、オプションの引数を取得
+input_month = ARGV.getopts("m:")
+
+#　カレンダーは当年のみ
+year = Date.parse("#{Date.today}").year
+
+#　オプションありの場合は指定月、無しの場合は実行月を取得
+month = input_month["m"] ? input_month["m"].to_i : Date.parse("#{Date.today}").month
+
+#　月が有効値でない場合は例外を出す
+if month > 12
+    raise "#{month} is neither a month number (1..12) nor a name"
+end
+
+# 指定月または実行月の一ヶ月を作成
+one_month = Date.new(year, month)..Date.new(year, month, -1)
+
+# 最終的なカレンダーの入れ物（月〜日を 0~6 として扱う）
+calender = [['月','火','水','木','金','土','日',]]
+# 一週間の入れ物
+one_week = []
+one_month.map do |day|
+    # 対応した曜日の位置に日付を入れる
+    # 出力を整えるために１桁日でも2桁日として扱う
+    val_day_of_the_week = change_for_monday_start(day.wday)
+    one_week[val_day_of_the_week] = sprintf("%2d", Date.parse("#{day}").day)
+    # 日曜終わりのカレンダーなので、日曜が来るたびにカレンダーに追加する
+    if val_day_of_the_week == 6
+        # 月初や終わりには日付が割り当てられない曜日がありnilが入るので、
+        # スペース２文字に直す（出力を整えるために２文字）
+        tmp = one_week.map do |day|
+            day.nil? ? ("  "):(day)
+        end
+        calender.insert(-1, tmp)
+    end
+end
+
+# 出来上がったカレンダーの出力
+printf("%8d月 %d\n", month, year)
+calender.each do |week|
+    week.each do |day|
+        printf('%s ', day)
+    end
+    # 週ごとに改行
+    puts
+end


### PR DESCRIPTION
## やったこと
カレンダー出力プログラムの作成
・月曜始まり
・-mオプションの後に入力した指定月、実行年のカレンダーを出力
・引数無しの場合、実行月、実行年のカレンダーを出力

## 動作確認方法
ターミナルから、
* `calender.rb`
  * プログラムを実行した月、年のカレンダーが出力されること
* `calender.rb -m <任意の月>`
  * プログラム実行時に指定した月、実行した年のカレンダーが出力されること
* `calender.rb -m <存在しない月>`
  * `<指定月>  is neither a month number (1..12) nor a name `のエラー出力を行うこと

## その他
実行例
```
ZumiAir ruby % cal
      12月 2023        
日 月 火 水 木 金 土  
                1  2  
 3  4  5  6  7  8  9  
10 11 12 13 14 15 16  
17 18 19 20 21 22 23  
24 25 26 27 28 29 30  
31                    
ZumiAir ruby % ruby calender.rb 
      12月 2023
月 火 水 木 金 土 日 
             1  2  3 
 4  5  6  7  8  9 10 
11 12 13 14 15 16 17 
18 19 20 21 22 23 24 
25 26 27 28 29 30 31 
ZumiAir ruby % ruby calender.rb -m 2
       2月 2023
月 火 水 木 金 土 日 
       1  2  3  4  5 
 6  7  8  9 10 11 12 
13 14 15 16 17 18 19 
20 21 22 23 24 25 26 
ZumiAir ruby % ruby calender.rb -m 33
calender.rb:25:in `<main>': 33 is neither a month number (1..12) nor a name (RuntimeError)
```
